### PR TITLE
Binary send support

### DIFF
--- a/src/frame.c
+++ b/src/frame.c
@@ -506,7 +506,7 @@ static enum read_state frame_read_body(frame_t *f, char c)
 } 
 
 
-ssize_t frame_write(struct lws* wsi, frame_t *f) 
+ssize_t frame_write(struct lws* wsi, frame_t *f, int mode)
 {
 	size_t left; 
 	size_t n;
@@ -528,7 +528,7 @@ ssize_t frame_write(struct lws* wsi, frame_t *f)
 			
 	memcpy(ws_buf + LWS_SEND_BUFFER_PRE_PADDING, f->buf, left);
 
-	n = lws_write(wsi, &ws_buf[LWS_SEND_BUFFER_PRE_PADDING], left, LWS_WRITE_TEXT);
+	n = lws_write(wsi, &ws_buf[LWS_SEND_BUFFER_PRE_PADDING], left, mode);
 
 	/* assert(n == left); */
 	/* printf("stomp (frame_write): %zu bytes written\n", n); */

--- a/src/frame.h
+++ b/src/frame.h
@@ -41,7 +41,7 @@ int frame_cmd_set(frame_t *f, const char *cmd);
 int frame_hdr_add(frame_t *f, const char *key, const char *val);
 int frame_hdrs_add(frame_t *f, size_t hdrc, const struct stomp_hdr *hdrs);
 int frame_body_set(frame_t *f, const void *body, size_t len);
-ssize_t frame_write(struct lws* fd, frame_t *f);
+ssize_t frame_write(struct lws* fd, frame_t *f, int mode);
 
 size_t frame_cmd_get(frame_t *f, const char **cmd);
 size_t frame_hdrs_get(frame_t *f, const struct stomp_hdr **hdrs);

--- a/src/stomp.h
+++ b/src/stomp.h
@@ -101,7 +101,9 @@ int stomp_nack(stomp_session_t *, size_t, const struct stomp_hdr *);
 
 int stomp_commit(stomp_session_t *, size_t, const struct stomp_hdr *);
 
-int stomp_send(stomp_session_t *, size_t, const struct stomp_hdr *, const void *,
+int stomp_send_text(stomp_session_t *, size_t, const struct stomp_hdr *, const void *,
+    size_t);
+int stomp_send_bin(stomp_session_t *, size_t, const struct stomp_hdr *, const void *,
     size_t);
 
 int stomp_recv_cmd(stomp_session_t *, const unsigned char*, size_t);


### PR DESCRIPTION
Support sending binary messages as-is. The external interface
is changed and stomp_send() is no longer available; instead,
callers have to use either stomp_send_text() or stomp_send_bin().