### PR TITLE
Fix error handling in stomp_session_new()

### DIFF
--- a/src/stomp.c
+++ b/src/stomp.c
@@ -90,12 +90,15 @@ stomp_session_new(void *session_ctx)
 	s->ctx = session_ctx;
 	s->broker_fd = NULL;
 
-	if ((s->frame_out = frame_new()) == NULL)
+	if ((s->frame_out = frame_new()) == NULL) {
 		free(s);
+		return (NULL);
+	}
 
 	if ((s->frame_in = frame_new()) == NULL) {
 		free(s->frame_out);
 		free(s);
+		return (NULL);
 	}
 
 	return (s);


### PR DESCRIPTION
The error handling in `stomp_session_new()` is broken, and would cause
some serious problems if `frame_new()` ever returned NULL due to memory
allocation failure.